### PR TITLE
Export the `Path` variable rather than appending to it

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -188,24 +188,17 @@ try {
     const completeEnv = cmdOutput
         .filter(s => s.indexOf('=') != -1)
         .map(s => s.split('=', 2))
-    const filteredEnv = completeEnv
-        .filter(([key, _]) => key != 'Path' && !process.env[key])
+    const newEnvVars = completeEnv
+        .filter(([key, _]) => !process.env[key])
+    const newPath = completeEnv
+                        .filter(([key, _]) => key == 'Path')
+                        .map(([_, value]) => value)
+                        .join(';');
 
-    for (const [key, value] of filteredEnv) {
+    for (const [key, value] of newEnvVars) {
         core.exportVariable(key, value)
     }
-
-    const pathEntries = process.env['Path'].split(';')
-    const newPathEntries = completeEnv
-        .filter(([key, _]) => key == 'Path')
-        .map(([_, value]) => value)
-        .join(';')
-        .split(';')
-        .filter(path => pathEntries.indexOf(path) == -1)
-
-    for (const path of newPathEntries) {
-        core.addPath(path)
-    }
+    core.exportVariable('Path', newPath);
 
     console.log('environment updated')
 } catch (error) {

--- a/index.js
+++ b/index.js
@@ -71,24 +71,17 @@ try {
     const completeEnv = cmdOutput
         .filter(s => s.indexOf('=') != -1)
         .map(s => s.split('=', 2))
-    const filteredEnv = completeEnv
-        .filter(([key, _]) => key != 'Path' && !process.env[key])
+    const newEnvVars = completeEnv
+        .filter(([key, _]) => !process.env[key])
+    const newPath = completeEnv
+                        .filter(([key, _]) => key == 'Path')
+                        .map(([_, value]) => value)
+                        .join(';');
 
-    for (const [key, value] of filteredEnv) {
+    for (const [key, value] of newEnvVars) {
         core.exportVariable(key, value)
     }
-
-    const pathEntries = process.env['Path'].split(';')
-    const newPathEntries = completeEnv
-        .filter(([key, _]) => key == 'Path')
-        .map(([_, value]) => value)
-        .join(';')
-        .split(';')
-        .filter(path => pathEntries.indexOf(path) == -1)
-
-    for (const path of newPathEntries) {
-        core.addPath(path)
-    }
+    core.exportVariable('Path', newPath);
 
     console.log('environment updated')
 } catch (error) {


### PR DESCRIPTION
The `addPath` will invert the path ordering as each entry is appended to the
environment file, which is then reversed and prepended to the environment at the
end of the action.  This results in the additions being in reverse order.
However, since we know that `vsdevcmd` will adjust the path on both ends, simply
prefer to use the `exportVariable` rather than try to be clever to adjust the
path via `addPath`.

Fixes: #10.